### PR TITLE
【SDK】【MapboxGL】【修复】【无法监听tileMatrixSet的值变化】【杨琨】

### DIFF
--- a/mapboxgl/src/components/layer/ogc/OgcWmtsLayer.js
+++ b/mapboxgl/src/components/layer/ogc/OgcWmtsLayer.js
@@ -31,7 +31,11 @@ export default {
       let urlStr = me.url;
       let startIndex = urlStr.indexOf(replaceUpper);
       let endIndex = urlStr.indexOf("&",startIndex);
-      me.url = urlStr.substr(0,startIndex + replace.length + 1) + this[replace] + urlStr.substr(endIndex,urlStr.length);
+      me.url = urlStr.substr(0,startIndex + replace.length + 1) + this[replace];
+      if(endIndex >= 0){
+        me.url += urlStr.substr(endIndex,urlStr.length);
+      }
+      me._url = me.url;
     });
   },
   methods: {


### PR DESCRIPTION
修改如下：
1、原来：仅判断tileMatrixSet的index在url中间的情况。新增判断：当tileMatrixSet在末尾时的处理情况。
2、原来：仅修改了this.url。新增：也会对this._url进行修改。