### PR TITLE
【MapboxGL】【修复】【com变量为data中的变量需要在前面加上this】【改变卷帘显示方向的参数时没有监听参数的变化导致卷帘方向…

### DIFF
--- a/mapboxgl/src/components/UI/controls/compare/CompareControl.vue
+++ b/mapboxgl/src/components/UI/controls/compare/CompareControl.vue
@@ -16,7 +16,11 @@ export default {
   },
   components: {},
 
-  watch: {},
+  watch: {
+      orientation() {
+          this.initMap();
+      }
+  },
 
   data() {
     return {
@@ -85,7 +89,7 @@ export default {
     },
     removeMap() {
       if (this.com) {
-        com.remove();
+        this.com.remove();
       }
     }
   },


### PR DESCRIPTION
…没有变化】